### PR TITLE
feat: Add deprecation warning on `reload()` and `done()`

### DIFF
--- a/stock_indicators/indicators/common/results.py
+++ b/stock_indicators/indicators/common/results.py
@@ -1,5 +1,6 @@
 from datetime import datetime as PyDateTime
 from typing import Callable, Iterable, List, Optional, Type, TypeVar
+from warnings import warn
 
 from stock_indicators._cslib import CsResultBase
 from stock_indicators._cstypes import DateTime as CsDateTime
@@ -35,8 +36,10 @@ class IndicatorResults(List[_T]):
     def reload(self):
         """
         Reload a C# array of the results to perform more operations.
-        It is usually called after `done()`
+        It is usually called after `done()`.
+        This method is deprecated. It will be removed in the next version.
         """
+        warn('This method is deprecated.', DeprecationWarning, stacklevel=2)
         if self._csdata is None:
             self._csdata = [ _._csdata for _ in self ]
         return self
@@ -45,7 +48,9 @@ class IndicatorResults(List[_T]):
         """
         Remove a C# array of the results after finishing all operations.
         It is not necessary but saves memory.
+        This method is deprecated. It will be removed in the next version.
         """
+        warn('This method is deprecated.', DeprecationWarning, stacklevel=2)
         self._csdata = None
         return self
 

--- a/stock_indicators/indicators/gator.py
+++ b/stock_indicators/indicators/gator.py
@@ -32,8 +32,7 @@ def get_gator(quotes):
         results = CsIndicator.GetGator[Quote](CsList(Quote, quotes))
     else:
         # Get C# objects.
-        if isinstance(quotes, IndicatorResults):
-            quotes.reload()
+        if isinstance(quotes, IndicatorResults) and quotes._csdata is not None:
             cs_results = quotes._csdata
         else:
             cs_results = [ q._csdata for q in quotes ]


### PR DESCRIPTION
### Description

 - Deprecate `reload()` and `done()`
 - No memory saving profit
 - After removing them, it is guranteed that the type of `_csdata` is always `IEnumerable`(C#).



### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
