### PR TITLE
ci: Fix for breaking `upload-artifact`

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
-
+        include-hidden-files: true
 
   # This will be triggered only when a tag is pushed
   publish-to-pypi:


### PR DESCRIPTION
Breaking change from [upload-artifact](https://github.com/actions/upload-artifact) v4.4.0 that now requires explicit need to place `include-hidden-files: true` under `with:` block.