### PR TITLE
chore: Update issue templates with new Types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report.
-type: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -15,25 +15,6 @@ body:
       placeholder: Tell us what you see!
     validations:
       required: true
-  - type: textarea
-    id: usage
-    attributes:
-      label: Code usage
-      description: How did you write your code? Provide a code snippet. _This will be auto-formatted as code, so no need for \`backticks\`_. Also, consider providing your source _quotes_ as a _JSON, CSV, or Excel_ file in the "What happened?" field.
-      render: python
-      placeholder: |
-        // example (put your own code here)
-        results = indicators.get_ema(quotes, 14)
-    validations:
-      required: false
-  - type: textarea
-    id: logs
-    attributes:
-      label: Log output
-      description: Please copy and paste any relevant log output. _This will be auto-formatted as code, so no need for \`backticks\`_.
-      render: bash
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: If your request is urgent, please review our [sponsorship tiers](https://github.com/sponsors/facioquo). For contract custom development, contact [Skender Co.](https://skenderco.com)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: File a bug report.
-labels: ["bug"]
+type: ["bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project.
-labels: ["enhancement"]
+type: ["feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project.
-type: ["feature"]
+type: Feature
 body:
   - type: markdown
     attributes:
@@ -14,23 +14,6 @@ body:
       placeholder: I'm always frustrated when [...]
     validations:
       required: true
-  - type: textarea
-    id: solution
-    attributes:
-      label: an idea
-      description: Any suggestions for a solution? Include any alternative solutions you've considered. If requesting a new [reputable indicator](https://github.com/DaveSkender/Stock.Indicators/discussions/1024), please provide the original author's publication of its recipe.
-      placeholder: I'd love it if the library could [...]
-    validations:
-      required: false
-  - type: textarea
-    id: usage
-    attributes:
-      label: code example
-      description: Any proposed implementation syntax? _This will be auto-formatted as code, so no need for \`backticks\`_.
-      render: shell
-      placeholder: foo = awesome_new_feature(quotes, whatDaYaThink);
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: If your request is urgent, please review our [sponsorship tiers](https://github.com/sponsors/facioquo). For contract custom development, contact [Skender Co.](https://skenderco.com)


### PR DESCRIPTION
Fixes #417

Update Issue and PR templates to use new Type markers.

* Replace the `labels` field with the `type` field and set it to "bug" in `.github/ISSUE_TEMPLATE/bug_report.yml`.
* Replace the `labels` field with the `type` field and set it to "feature" in `.github/ISSUE_TEMPLATE/feature_request.yml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/facioquo/stock-indicators-python/pull/419?shareId=2c4ac296-323e-43d0-9a55-273210e41d0b).