### PR TITLE
ci: Fix PR title linter, add ARM64 runner

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
 #### done when
 
-- [ ] Implement
 - [ ] Fix: #
+
+#### the details
+<!-- add Copilot generated summary here -->

--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -1,7 +1,7 @@
 name: Pull request
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-24.04-arm, macos-latest]
         python-version: ["3.8", "3.12"]
         dotnet-version: ["6.x", "9.x"]
 


### PR DESCRIPTION
#### done when

- [x] use `pull_request_target` for OSS projects that use Forks
- [x] use ARM64 Linux in unit test runners matrix

#### the details

This pull request includes changes to the GitHub workflows to update the pull request event and testing environments. The most important changes include modifying the event type for pull request workflows and updating the operating system versions in the test matrix.

Updates to GitHub workflows:

* [`.github/workflows/lint-pull-request.yml`](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceL4-R4): Changed the event type from `pull_request` to `pull_request_target` to ensure the workflow runs with the correct permissions.
* [`.github/workflows/test-indicators.yml`](diffhunk://#diff-1e6ce7fdb17acdc0416421b7fe6b63ebec67f618f44b8b9a911dc14e81ec2e09L19-R19): Updated the operating system versions in the test matrix to include `ubuntu-24.04-arm` instead of `ubuntu-latest`.