### PR TITLE
ci: Update workflows

### DIFF
--- a/.github/workflows/test-code-coverage.yml
+++ b/.github/workflows/test-code-coverage.yml
@@ -6,9 +6,14 @@ name: Test code coverage
 on:
   push:
     branches: ["main"]
-  pull_request:
+  pull_request_target:
     branches: ["*"]
   workflow_dispatch:
+
+# Limit concurrent runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -18,9 +23,15 @@ jobs:
     name: indicators
     runs-on: ubuntu-latest
 
+    env:
+      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+
     steps:
-      - name: Checkout source
+      - name: Checkout PR
         uses: actions/checkout@v4
+        with:
+          # Explicitly checkout PR code
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -31,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
           cache: "pip"
 
       - name: Install dependencies

--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -16,24 +16,44 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-24.04-arm, macos-latest]
-        python-version: ["3.8", "3.12"]
-        dotnet-version: ["6.x", "9.x"]
+        # ref: https://github.com/actions/runner-images#readme
+
+        include:
+
+          # oldest combinations
+          - os: macos-13
+            dotnet-version: "6.x"
+            python-version: "3.8"
+          - os: ubuntu-20.04
+            dotnet-version: "6.x"
+            python-version: "3.8"
+          - os: windows-2019
+            dotnet-version: "6.x"
+            python-version: "3.8"
+
+          # newest combinations
+          - os: macos-15
+            dotnet-version: "9.x"
+            python-version: "3.13"
+            post-summary: true
+          - os: ubuntu-24.04-arm
+            dotnet-version: "9.x"
+            python-version: "3.13"
+            post-summary: true
+          - os: windows-2025
+            dotnet-version: "9.x"
+            python-version: "3.13"
+            post-summary: true
 
     runs-on: ${{ matrix.os }}
     name: "Py${{ matrix.python-version }}/.NET${{ matrix.dotnet-version }} on ${{ matrix.os }}"
-
-    env:
-
-      # identify configurations that post test reports
-      POST_REPORT: ${{ matrix.python-version == '3.12' && matrix.dotnet-version == '9.x' }}
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
       - name: Check debug settings
-        if: env.POST_REPORT == 'true'
+        if: ${{ matrix.post-summary }} == 'true'
         shell: bash
         run: |
           echo "Checking for debug logging settings in package files..."
@@ -60,7 +80,7 @@ jobs:
           cache: "pip"
 
       - name: Verify DLL presence
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         run: |
           ls -la stock_indicators/_cslib/lib/
           if [ ! -f stock_indicators/_cslib/lib/Skender.Stock.Indicators.dll ]; then
@@ -77,9 +97,10 @@ jobs:
 
       - name: Test indicators
         run: pytest -vr A tests --junitxml=test-results.xml
+        continue-on-error: true
 
       - name: Post test summary
         uses: test-summary/action@v2
-        if: env.POST_REPORT == 'true' && always()
+        if: ${{ matrix.post-summary }} == 'true'
         with:
           paths: test-results.xml


### PR DESCRIPTION
#### done when

- [x] use oldest and newest matrix combos for CI tests
- [x] allow Codacy to report from Fork-based PRs

#### the details

This pull request includes several updates to the GitHub Actions workflows to improve test code coverage and indicators. The changes involve modifying the workflow triggers, adding concurrency limits, updating environment variables, and refining the job matrix configurations.

Key changes include:

### Workflow Trigger and Concurrency:

* [`.github/workflows/test-code-coverage.yml`](diffhunk://#diff-a56235f489cdc191f584a3562a2725698debc96ce17ee6e89ed6d4e3ac99c4dcL9-R17): Changed the trigger from `pull_request` to `pull_request_target` and added concurrency limits to prevent multiple runs from overlapping.

### Environment Variables and Checkout:

* [`.github/workflows/test-code-coverage.yml`](diffhunk://#diff-a56235f489cdc191f584a3562a2725698debc96ce17ee6e89ed6d4e3ac99c4dcR26-R34): Added the `CODACY_PROJECT_TOKEN` environment variable and updated the checkout step to explicitly reference the pull request code.

### Python Version Update:

* [`.github/workflows/test-code-coverage.yml`](diffhunk://#diff-a56235f489cdc191f584a3562a2725698debc96ce17ee6e89ed6d4e3ac99c4dcL34-R45): Updated the Python version from 3.12 to 3.13 for the `Setup Python` step.

### Job Matrix Configuration:

* [`.github/workflows/test-indicators.yml`](diffhunk://#diff-1e6ce7fdb17acdc0416421b7fe6b63ebec67f618f44b8b9a911dc14e81ec2e09L19-R56): Refined the job matrix to include specific OS, .NET, and Python version combinations, and added a `post-summary` flag for certain configurations.

### Conditional Steps and Error Handling:

* [`.github/workflows/test-indicators.yml`](diffhunk://#diff-1e6ce7fdb17acdc0416421b7fe6b63ebec67f618f44b8b9a911dc14e81ec2e09L63-R83): Updated conditions for steps based on the new `post-summary` flag and added `continue-on-error: true` for the `Test indicators` step. [[1]](diffhunk://#diff-1e6ce7fdb17acdc0416421b7fe6b63ebec67f618f44b8b9a911dc14e81ec2e09L63-R83) [[2]](diffhunk://#diff-1e6ce7fdb17acdc0416421b7fe6b63ebec67f618f44b8b9a911dc14e81ec2e09R100-R104)
