### PR TITLE
chore: Update gem packages

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,6 +42,26 @@
       "command": "pytest --cov=stock_indicators --cov-report=term-missing",
       "group": "none",
       "problemMatcher": []
+    },
+    {
+      "label": "Docs: Serve (Jekyll)",
+      "type": "shell",
+      "command": "bundle exec jekyll serve -o",
+      "options": {
+        "cwd": "${workspaceFolder}/docs"
+      },
+      "group": "none",
+      "problemMatcher": []
+    },
+    {
+      "label": "Docs: Update Ruby Packages",
+      "type": "shell",
+      "command": "bundle install && bundle update",
+      "options": {
+        "cwd": "${workspaceFolder}/docs"
+      },
+      "group": "none",
+      "problemMatcher": []
     }
   ]
 }

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.2)
+    activesupport (8.0.2.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -17,8 +17,8 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -27,8 +27,8 @@ GEM
     commonmarker (0.23.11)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
-    cssminify2 (2.0.1)
-    csv (3.3.4)
+    cssminify2 (2.1.0)
+    csv (3.3.5)
     dnsruby (1.72.3)
       base64 (~> 0.2.0)
       simpleidn (~> 0.2.1)
@@ -36,18 +36,17 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.16.0)
+    ethon (0.17.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
     execjs (2.10.0)
-    faraday (2.13.1)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
+    faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    ffi (1.17.2)
+    ffi (1.17.2-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -227,7 +226,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.12.2)
+    json (2.13.2)
     json-minify (0.0.3)
       json (> 0)
     kramdown (2.4.0)
@@ -240,7 +239,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
-    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -248,12 +246,7 @@ GEM
     minitest (5.25.5)
     net-http (0.6.0)
       uri
-    nokogiri (1.18.8)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.18.8-x64-mingw-ucrt)
-      racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.9-x64-mingw-ucrt)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -294,8 +287,6 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
-  x64-mingw32
-  x86_64-linux
 
 DEPENDENCIES
   faraday
@@ -310,4 +301,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.4.7
+   2.5.18


### PR DESCRIPTION
This pull request adds new development tasks to the `.vscode/tasks.json` file to streamline working with documentation. The most important changes are the addition of tasks for serving the documentation site locally and updating Ruby packages used for documentation.

Documentation workflow improvements:

* Added a "Docs: Serve (Jekyll)" task to run the Jekyll server from the `docs` directory, making it easier to preview documentation changes locally.
* Added a "Docs: Update Ruby Packages" task that installs and updates Ruby dependencies in the `docs` directory, simplifying package management for documentation.